### PR TITLE
DOP-3692: Create new route for fetching data by project and branch

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -1,5 +1,9 @@
 # Connection string to be used for MongoDB to connect to Atlas
 ATLAS_URI=mongodb://localhost:27017
+# The user who performed the build or uploaded build data through the persistence 
+# module. By default, this should be docsworker-xlarge. Otherwise, it should be 
+# your local machine's user (whoami)
+BUILDER_USER=docsworker-xlarge
 # The port number used for the app server
 PORT=3000
 # snooty_* db to connect to for build artifacts

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,6 +4,7 @@ import { MongoClient } from 'mongodb';
 // Configure dotenv early so env variables can be read in imported files
 dotenv.config();
 import buildsRouter from './routes/builds';
+import projectsRouter from './routes/projects';
 import { setupClient } from './services/database';
 
 interface AppSettings {
@@ -17,6 +18,7 @@ export const setupApp = async ({ mongoClient }: AppSettings) => {
 
   const app = express();
   app.use('/builds', buildsRouter);
+  app.use('/projects', projectsRouter);
 
   return app;
 };

--- a/src/routes/builds.ts
+++ b/src/routes/builds.ts
@@ -1,12 +1,12 @@
 import express from 'express';
-import { findAllBuildData } from '../services/database';
+import { findAllBuildDataById } from '../services/database';
 
 const router = express.Router();
 
 // Given a buildId corresponding to a persistence module build/upload, return all
 // documents (page ASTs, metadata, assets) associated for that build
 router.get('/:buildId/documents', async (req, res) => {
-  const data = await findAllBuildData(req.params.buildId);
+  const data = await findAllBuildDataById(req.params.buildId);
   res.send({ data, timestamp: Date.now() });
 });
 

--- a/src/routes/projects.ts
+++ b/src/routes/projects.ts
@@ -1,0 +1,15 @@
+import express from 'express';
+import { findAllBuildDataByProject } from '../services/database';
+
+const router = express.Router();
+
+// Given a Snooty project name + branch combination, return all build data 
+// (page ASTs, metadata, assets) for that combination. This should always be the
+// latest build data at time of call
+router.get('/:snootyProject/:branch/documents', async (req, res) => {
+  const { snootyProject, branch } = req.params;
+  const data = await findAllBuildDataByProject(snootyProject, branch);
+  res.send({ data, timestamp: Date.now() });
+});
+
+export default router;

--- a/src/routes/projects.ts
+++ b/src/routes/projects.ts
@@ -3,7 +3,7 @@ import { findAllBuildDataByProject } from '../services/database';
 
 const router = express.Router();
 
-// Given a Snooty project name + branch combination, return all build data 
+// Given a Snooty project name + branch combination, return all build data
 // (page ASTs, metadata, assets) for that combination. This should always be the
 // latest build data at time of call
 router.get('/:snootyProject/:branch/documents', async (req, res) => {

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -146,7 +146,7 @@ export const findAllBuildDataByProject = async (projectName: string, branch: str
   const user = process.env.BUILDER_USER ?? 'docsworker-xlarge';
   const pageIdPrefix = `${projectName}/${user}/${branch}`;
   const pagesQuery = {
-    page_id: { $regex: new RegExp(`^${pageIdPrefix}`) },
+    page_id: { $regex: new RegExp(`^${pageIdPrefix}/`) },
   };
   const metadataQuery = {
     project: projectName,

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -117,7 +117,7 @@ const findAndPrepAssets = async (pages: PageDocType[]) => {
   return responseAssets;
 };
 
-const findPagesAndAssets = async(filter: Filter<any>, pagesColl: string) => {
+const findPagesAndAssets = async (filter: Filter<any>, pagesColl: string) => {
   const dbSession = await db();
   const documents = await dbSession.collection<PageDocType>(pagesColl).find(filter).toArray();
   const responseAssets = await findAndPrepAssets(documents);
@@ -145,7 +145,7 @@ export const findAllBuildDataById = async (buildId: string | ObjectId) => {
 export const findAllBuildDataByProject = async (projectName: string, branch: string) => {
   const user = process.env.BUILDER_USER ?? 'docsworker-xlarge';
   const pageIdPrefix = `${projectName}/${user}/${branch}`;
-  const pagesQuery = { 
+  const pagesQuery = {
     page_id: { $regex: new RegExp(`^${pageIdPrefix}`) },
   };
   const metadataQuery = {
@@ -155,7 +155,12 @@ export const findAllBuildDataByProject = async (projectName: string, branch: str
 
   const dbSession = await db();
   // Get the latest metadata document available for the Snooty project + branch
-  const metadata = await dbSession.collection(METADATA_COLLECTION).find(metadataQuery).sort('created_at', -1).limit(1).toArray();
+  const metadata = await dbSession
+    .collection(METADATA_COLLECTION)
+    .find(metadataQuery)
+    .sort('created_at', -1)
+    .limit(1)
+    .toArray();
   const pagesAndAssets = await findPagesAndAssets(pagesQuery, UPDATED_PAGES_COLLECTION);
 
   return {

--- a/tests/globalSetup.ts
+++ b/tests/globalSetup.ts
@@ -1,9 +1,49 @@
+import { Db, MongoClient, ObjectId } from 'mongodb';
 import { MongoMemoryServer } from 'mongodb-memory-server';
+import samplePageDocuments from './sampleData/documents.json';
+import sampleUpdatedPageDocuments from './sampleData/updatedDocuments.json';
+import sampleMetadata from './sampleData/metadata.json';
+import sampleAssets from './sampleData/assets.json';
+
+// Replaces string build_id with ObjectId to ensure reference is accurate
+// Using $oid in the json yields an actual object when inserted
+const constructNewBuildIds = (docs: any) => {
+  docs.forEach((doc: any) => {
+    doc.build_id = new ObjectId(doc.build_id);
+  });
+};
+
+const loadSampleDataInCollection = async (
+  db: Db,
+  documents: any,
+  collectionName: string,
+  constructBuildIds?: boolean
+) => {
+  const collection = db.collection(collectionName);
+  if (constructBuildIds) {
+    constructNewBuildIds(documents);
+  }
+  await collection.insertMany(documents);
+};
+
+const loadData = async() => {
+  const client = new MongoClient(process.env.ATLAS_URI!);
+  const db = client.db(process.env.SNOOTY_DB_NAME!);
+
+  await loadSampleDataInCollection(db, samplePageDocuments, 'documents', true);
+  await loadSampleDataInCollection(db, sampleUpdatedPageDocuments, 'updated_documents', true);
+  await loadSampleDataInCollection(db, sampleMetadata, 'metadata', true);
+  await loadSampleDataInCollection(db, sampleAssets, 'assets');
+
+  await client.close();
+};
 
 export default async function globalSetup() {
   const instance = await MongoMemoryServer.create();
   const uri = instance.getUri();
   (global as any).__MONGOINSTANCE = instance;
   process.env.ATLAS_URI = uri.slice(0, uri.lastIndexOf('/'));
+  process.env.BUILDER_USER = 'docsworker-xlarge';
   process.env.SNOOTY_DB_NAME = 'snooty_dev';
+  await loadData();
 }

--- a/tests/globalSetup.ts
+++ b/tests/globalSetup.ts
@@ -26,7 +26,7 @@ const loadSampleDataInCollection = async (
   await collection.insertMany(documents);
 };
 
-const loadData = async() => {
+const loadData = async () => {
   const client = new MongoClient(process.env.ATLAS_URI!);
   const db = client.db(process.env.SNOOTY_DB_NAME!);
 

--- a/tests/routes/projects.test.ts
+++ b/tests/routes/projects.test.ts
@@ -1,8 +1,9 @@
 import { MongoClient } from 'mongodb';
 import request from 'supertest';
 import { setupApp } from '../../src/app';
+import sampleUpdatedPageDocuments from '../sampleData/updatedDocuments.json';
 
-describe('Test documents routes', () => {
+describe('Test projects routes', () => {
   // process.env.ATLAS_URI should be defined by default in globalSetup.ts
   const client = new MongoClient(process.env.ATLAS_URI!);
   let app: Express.Application;
@@ -15,12 +16,13 @@ describe('Test documents routes', () => {
     await client.close();
   });
 
-  it('should return all data based on build ID', async () => {
-    const res = await request(app).get('/builds/642ec854c38bedd45ed3d1fc/documents');
+  it('should return all data based on project ID', async () => {
+    const res = await request(app).get('/projects/docs/master/documents');
     expect(res.status).toBe(200);
-    expect(res.body.data.documents).toHaveLength(3);
+    expect(res.body.data.documents).toHaveLength(sampleUpdatedPageDocuments.length - 2);
     expect(res.body.data.metadata).toHaveLength(1);
     expect(res.body.data.assets).toHaveLength(3);
     expect(res.body.timestamp).toBeTruthy();
   });
 });
+

--- a/tests/routes/projects.test.ts
+++ b/tests/routes/projects.test.ts
@@ -25,4 +25,3 @@ describe('Test projects routes', () => {
     expect(res.body.timestamp).toBeTruthy();
   });
 });
-

--- a/tests/sampleData/documents.json
+++ b/tests/sampleData/documents.json
@@ -11,7 +11,7 @@
     }
   },
   {
-    "page_id": "docs/docsworkerx-large/master/tutorial/insert-documents",
+    "page_id": "docs/docsworker-xlarge/master/tutorial/insert-documents",
     "filename": "tutorial/insert-documents.txt",
     "ast": {},
     "source": "1 asset example",
@@ -27,7 +27,7 @@
     }
   },
   {
-    "page_id": "docs/raymundrodriguez/master/tutorial/update-documents",
+    "page_id": "docs/docsworker-xlarge/master/tutorial/update-documents",
     "filename": "tutorial/update-documents.txt",
     "ast": {},
     "source": "2 assets example",

--- a/tests/sampleData/updatedDocuments.json
+++ b/tests/sampleData/updatedDocuments.json
@@ -1,0 +1,100 @@
+[
+  {
+    "page_id": "docs/docsworker-xlarge/master/data-center-awareness",
+    "filename": "data-center-awareness.txt",
+    "ast": {
+      "foo": "no assets"
+    },
+    "static_assets": [],
+    "created_at": {
+      "$date": "2023-04-06T13:25:40.000Z"
+    },
+    "updated_at": {
+      "$date": "2023-04-06T13:25:40.000Z"
+    },
+    "deleted": false
+  },
+  {
+    "page_id": "docs/docsworker-xlarge/master/data-center-foo",
+    "filename": "data-center-foo.txt",
+    "ast": {
+      "foo": "deleted"
+    },
+    "static_assets": [],
+    "created_at": {
+      "$date": "2023-04-06T13:25:40.000Z"
+    },
+    "updated_at": {
+      "$date": "2023-04-06T14:25:40.000Z"
+    },
+    "deleted": true
+  },
+  {
+    "page_id": "docs/docsworker-xlarge/master/tutorial/insert-documents",
+    "filename": "tutorial/insert-documents.txt",
+    "ast": {
+      "foo": "1 asset example"
+    },
+    "static_assets": [
+      {
+        "checksum": "d4dbe419766d19842ba5624cb41f6b873a513b620049e759a923894bef17742c",
+        "key": "/images/CSFLE_Master_Key_KMS.png"
+      }
+    ],
+    "created_at": {
+      "$date": "2023-04-06T13:25:40.000Z"
+    },
+    "updated_at": {
+      "$date": "2023-04-06T14:25:40.000Z"
+    },
+    "deleted": false
+  },
+  {
+    "page_id": "docs/docsworker-xlarge/master/tutorial/update-documents",
+    "filename": "tutorial/update-documents.txt",
+    "ast": {},
+    "static_assets": [
+      {
+        "checksum": "ba1b4507fc789827edd02f979130e9633a0020b498cba915c0773403b37aedd5",
+        "key": "/images/compass-update-doc-button.png"
+      },
+      {
+        "checksum": "9617b2e1a8065e4a1699c15fc8ea1e085a41b4021debeaef1793a6cb431a9659",
+        "key": "/images/compass-update-edit-mode.png"
+      }
+    ],
+    "created_at": {
+      "$date": "2023-04-06T13:25:40.000Z"
+    },
+    "updated_at": {
+      "$date": "2023-04-06T13:25:40.000Z"
+    },
+    "deleted": false
+  },
+  {
+    "page_id": "not-docs/docsworker-xlarge/master/tutorial/update-documents",
+    "filename": "tutorial/update-documents.txt",
+    "ast": {},
+    "static_assets": [],
+    "created_at": {
+      "$date": "2023-04-06T13:25:40.000Z"
+    },
+    "updated_at": {
+      "$date": "2023-04-06T13:25:40.000Z"
+    },
+    "deleted": false
+  },
+  {
+    "page_id": "docs/docsworker-xlarge/not-master/tutorial/update-documents",
+    "filename": "tutorial/update-documents.txt",
+    "ast": {},
+    "static_assets": [],
+    "created_at": {
+      "$date": "2023-04-06T13:25:40.000Z"
+    },
+    "updated_at": {
+      "$date": "2023-04-06T13:25:40.000Z"
+    },
+    "deleted": false
+  }
+]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,7 @@
 
     /* Modules */
     "module": "commonjs",                                /* Specify what module code is generated. */
-    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    "rootDir": "./src",                                  /* Specify the root folder within your source files. */
     // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
@@ -99,5 +99,6 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
-  }
+  },
+  "exclude": ["node_modules", "tests", "dist"]
 }


### PR DESCRIPTION
### Ticket

DOP-3692

### Notes

* Breaks off existing logic to get build data. This should allow different routes to fetch the data based on their needs.
* Adds new sample data for tests
* Moves database setup to global setup since all tests expect to work with the same data. This could change in the future if we need more variety in tests and data
* Changes TypeScript settings to avoid building unwanted test files