### PR TITLE
:bug: DOP-3872 adds logic for dynamically handling branch full urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ npm run format:fix
 
 ## Endpoints
 
-The following are the base URL for the endpoints use in this Data API;
+The following are the base URLs for the Snooty Data API;
 
 - `https://snooty-data-api.mongodb.com/`
 - `https://snooty-data-api.docs.staging.corp.mongodb.com/`

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ npm run format:fix
 
 ## Endpoints
 
-The base URL for the endpoints
+The following are the base URL for the endpoints use in this Data API;
 
 - `https://snooty-data-api.mongodb.com/`
 - `https://snooty-data-api.docs.staging.corp.mongodb.com/`

--- a/README.md
+++ b/README.md
@@ -59,3 +59,12 @@ If there are errors flagged through `prettier`, use:
 ```
 npm run format:fix
 ```
+
+## Endpoints
+
+The base URL for the endpoints
+
+- `https://snooty-data-api.mongodb.com/`
+- `https://snooty-data-api.docs.staging.corp.mongodb.com/`
+
+

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ npm run format:fix
 
 ## Endpoints
 
-The following are the base URLs for the Snooty Data API;
+The following are the base URLs for the Snooty Data API:
 
 - `https://snooty-data-api.mongodb.com/`
 - `https://snooty-data-api.docs.staging.corp.mongodb.com/`

--- a/README.md
+++ b/README.md
@@ -66,5 +66,3 @@ The base URL for the endpoints
 
 - `https://snooty-data-api.mongodb.com/`
 - `https://snooty-data-api.docs.staging.corp.mongodb.com/`
-
-

--- a/src/services/pool.ts
+++ b/src/services/pool.ts
@@ -89,13 +89,26 @@ export const findAllRepos = async (options: FindOptions = {}, reqId?: string) =>
 
 const getRepoUrl = (baseUrl: string, prefix: string) => assertTrailingSlash(baseUrl) + assertTrailingSlash(prefix);
 
-const mapBranches = (branches: BranchEntry[], fullBaseUrl: string) =>
-  branches.map((branchEntry) => ({
+/**
+ * 
+ * branch full url util, 
+ * It dynamically handling url slugs for
+ * repos that have more then one version
+ */
+const setBranchFullUrl = (branchEntry: BranchEntry, fullBaseUrl: string, useUrlSlug = true) => {
+  const urlSlug = useUrlSlug && branchEntry?.usrSlug ? branchEntry.urlSlug : '';
+  return `${fullBaseUrl}${urlSlug}`;
+}
+
+
+const mapBranches = (branches: BranchEntry[], fullBaseUrl: string) => {
+  return branches.map((branchEntry) => ({
     gitBranchName: branchEntry.gitBranchName,
     active: branchEntry.active,
-    fullUrl: `${fullBaseUrl}` + (branchEntry.urlSlug ? `${branchEntry.urlSlug}` : ''),
+    fullUrl: setBranchFullUrl(branchEntry, fullBaseUrl, branches.length > 1),
     isStableBranch: !!branchEntry.isStableBranch,
-  }));
+  }))
+}
 
 const mapRepos = (repo: RepoDocument): RepoResponse => ({
   repoName: repo.repoName,

--- a/src/services/pool.ts
+++ b/src/services/pool.ts
@@ -95,7 +95,7 @@ const getRepoUrl = (baseUrl: string, prefix: string) => assertTrailingSlash(base
  * It dynamically handling url slugs for
  * repos that have more then one version
  */
-const setBranchFullUrl = (branchEntry: BranchEntry, fullBaseUrl: string, useUrlSlug = true) => {
+const getBranchFullUrl = (branchEntry: BranchEntry, fullBaseUrl: string, useUrlSlug = true) => {
   const urlSlug = useUrlSlug && branchEntry?.urlSlug ? branchEntry.urlSlug : '';
   return `${fullBaseUrl}${urlSlug}`;
 };
@@ -104,7 +104,7 @@ const mapBranches = (branches: BranchEntry[], fullBaseUrl: string) => {
   return branches.map((branchEntry) => ({
     gitBranchName: branchEntry.gitBranchName,
     active: branchEntry.active,
-    fullUrl: setBranchFullUrl(branchEntry, fullBaseUrl, branches.length > 1),
+    fullUrl: getBranchFullUrl(branchEntry, fullBaseUrl, branches.length > 1),
     isStableBranch: !!branchEntry.isStableBranch,
   }));
 };

--- a/src/services/pool.ts
+++ b/src/services/pool.ts
@@ -96,7 +96,7 @@ const getRepoUrl = (baseUrl: string, prefix: string) => assertTrailingSlash(base
  * repos that have more then one version
  */
 const setBranchFullUrl = (branchEntry: BranchEntry, fullBaseUrl: string, useUrlSlug = true) => {
-  const urlSlug = useUrlSlug && branchEntry?.usrSlug ? branchEntry.urlSlug : '';
+  const urlSlug = useUrlSlug && branchEntry?.urlSlug ? branchEntry.urlSlug : '';
   return `${fullBaseUrl}${urlSlug}`;
 };
 

--- a/src/services/pool.ts
+++ b/src/services/pool.ts
@@ -90,16 +90,15 @@ export const findAllRepos = async (options: FindOptions = {}, reqId?: string) =>
 const getRepoUrl = (baseUrl: string, prefix: string) => assertTrailingSlash(baseUrl) + assertTrailingSlash(prefix);
 
 /**
- * 
- * branch full url util, 
+ *
+ * branch full url util,
  * It dynamically handling url slugs for
  * repos that have more then one version
  */
 const setBranchFullUrl = (branchEntry: BranchEntry, fullBaseUrl: string, useUrlSlug = true) => {
   const urlSlug = useUrlSlug && branchEntry?.usrSlug ? branchEntry.urlSlug : '';
   return `${fullBaseUrl}${urlSlug}`;
-}
-
+};
 
 const mapBranches = (branches: BranchEntry[], fullBaseUrl: string) => {
   return branches.map((branchEntry) => ({
@@ -107,8 +106,8 @@ const mapBranches = (branches: BranchEntry[], fullBaseUrl: string) => {
     active: branchEntry.active,
     fullUrl: setBranchFullUrl(branchEntry, fullBaseUrl, branches.length > 1),
     isStableBranch: !!branchEntry.isStableBranch,
-  }))
-}
+  }));
+};
 
 const mapRepos = (repo: RepoDocument): RepoResponse => ({
   repoName: repo.repoName,


### PR DESCRIPTION
[staging: /projects](https://snooty-data-api.docs.staging.corp.mongodb.com/projects)


If you pull down the changes from this branch and run it locally, you can go to `/projects` and compare the URL in `fullUrl`. You will see that `master` is no longer included in the path compared to it being included in the staging API. 

Currently, production doesn't have it, but that could have been a side-effect from a change in Hapley, but that isn't considered at this moment a stable fix. 
