### PR TITLE
DOP-3894: filter out internalOnly repos from /prod/projects route

### DIFF
--- a/src/routes/projects.ts
+++ b/src/routes/projects.ts
@@ -16,8 +16,9 @@ const router = express.Router();
 // get all repo_branches route
 router.get('/', async (req, res, next) => {
   try {
+    const isProd = req.baseUrl.includes('prod');
     const reqId = getRequestId(req);
-    const data = await findAllRepos({}, reqId);
+    const data = await findAllRepos({}, isProd, reqId);
     res.send({ data: data });
   } catch (err) {
     next(err);

--- a/src/services/pool.ts
+++ b/src/services/pool.ts
@@ -75,9 +75,11 @@ export const findAllRepos = async (options: FindOptions = {}, isProd: boolean, r
       },
     };
     const findOptions = { ...defaultSort, ...options, ...strictOptions };
-    const query: Filter<RepoDocument> = isProd ? {
-      internalOnly: false,
-    } : {};
+    const query: Filter<RepoDocument> = isProd
+      ? {
+          internalOnly: false,
+        }
+      : {};
     return db.collection<RepoDocument>(REPOS_COLLECTION).find(query, findOptions).map(mapRepos).toArray();
   } catch (e) {
     logger.error(createMessage(`Error while finding all repos: ${e}`, reqId));

--- a/src/services/pool.ts
+++ b/src/services/pool.ts
@@ -60,7 +60,7 @@ export const initPoolDb = (client: MongoClient) => {
   return db;
 };
 
-export const findAllRepos = async (options: FindOptions = {}, reqId?: string) => {
+export const findAllRepos = async (options: FindOptions = {}, isProd: boolean, reqId?: string) => {
   try {
     const defaultSort: FindOptions = {
       sort: { repoName: 1 },
@@ -75,9 +75,9 @@ export const findAllRepos = async (options: FindOptions = {}, reqId?: string) =>
       },
     };
     const findOptions = { ...defaultSort, ...options, ...strictOptions };
-    const query: Filter<RepoDocument> = {
+    const query: Filter<RepoDocument> = isProd ? {
       internalOnly: false,
-    };
+    } : {};
     return db.collection<RepoDocument>(REPOS_COLLECTION).find(query, findOptions).map(mapRepos).toArray();
   } catch (e) {
     logger.error(createMessage(`Error while finding all repos: ${e}`, reqId));

--- a/src/services/pool.ts
+++ b/src/services/pool.ts
@@ -76,7 +76,7 @@ export const findAllRepos = async (options: FindOptions = {}, reqId?: string) =>
     };
     const findOptions = { ...defaultSort, ...options, ...strictOptions };
     const query: Filter<RepoDocument> = {
-      repoName: { $not: new RegExp('internal') },
+      internalOnly: false,
     };
     return db.collection<RepoDocument>(REPOS_COLLECTION).find(query, findOptions).map(mapRepos).toArray();
   } catch (e) {

--- a/tests/routes/projects.test.ts
+++ b/tests/routes/projects.test.ts
@@ -20,8 +20,23 @@ describe('Test projects routes', () => {
     await client.close();
   });
 
-  it('should return all external projects from the base route', async () => {
+  it('should return all external and internal projects from the base route', async () => {
     const res = await request(app).get('/projects');
+    expect(res.status).toBe(200);
+    const projects = JSON.parse(res.text)['data'];
+    expect(projects.length).toBeLessThanOrEqual(sampleReposBranches.length);
+    expect(projects.find((p: any) => p?.repoName === 'cloud-docs')).toBeTruthy();
+    expect(projects.filter((p: any) => p?.repoName === 'docs-mongodb-internal')).toBeTruthy();
+    projects.forEach((p: RepoResponse) => {
+      p.branches.forEach((b: BranchResponse) => {
+        expect(b.isStableBranch).toBeDefined();
+        expect(typeof b.isStableBranch).toBe('boolean');
+      });
+    });
+  });
+
+  it('should return all external projects from the prod base route', async () => {
+    const res = await request(app).get('/prod/projects');
     expect(res.status).toBe(200);
     const projects = JSON.parse(res.text)['data'];
     expect(projects.length).toBeLessThanOrEqual(sampleReposBranches.length);

--- a/tests/sampleData/reposBranches.ts
+++ b/tests/sampleData/reposBranches.ts
@@ -46,6 +46,7 @@ export const sampleReposBranches = [
       categoryName: 'atlas',
       categoryTitle: 'Atlas',
     },
+    internalOnly: false,
   },
   {
     _id: new ObjectId('5f6aaeb682989d521a60636a'),
@@ -88,6 +89,7 @@ export const sampleReposBranches = [
       dotcomprd: 'docs',
     },
     project: 'landing',
+    internalOnly: false,
   },
   {
     _id: new ObjectId('5fac1ce373a72fca02ec90c5'),
@@ -342,6 +344,7 @@ export const sampleReposBranches = [
       categoryName: 'manual',
       categoryTitle: 'MongoDB Server',
     },
+    internalOnly: false,
   },
   {
     _id: new ObjectId('614b9f5b8d181382ca755ade'),
@@ -383,5 +386,6 @@ export const sampleReposBranches = [
     },
     project: 'docs',
     groups: null,
+    internalOnly: true,
   },
 ];


### PR DESCRIPTION
### Ticket

DOP-3894

### Notes

A new boolean flag `internalOnly` has been added to every repo in the `repos_branches` collection. 

`GET` requests to `/prod/projects` route will now only return those repos which are marked `internalOnly: false`

For now, `GET` requests to `/projects` will return all repos. I was following the letter of the ticket on this one. I can also see a possibility of us still wanting these 6 repos to not be returned for this API. Easy to change to a wholesale filter.