### PR TITLE
DOP-4006: Add versionSelectorLabel to project response for branch

### DIFF
--- a/src/services/pool.ts
+++ b/src/services/pool.ts
@@ -17,6 +17,7 @@ interface BranchEntry {
   active: boolean;
   urlAliases: string[];
   isStableBranch: boolean;
+  versionSelectorLabel: string;
   [key: string]: any;
 }
 
@@ -107,6 +108,7 @@ const mapBranches = (branches: BranchEntry[], fullBaseUrl: string) => {
     gitBranchName: branchEntry.gitBranchName,
     active: branchEntry.active,
     fullUrl: getBranchFullUrl(branchEntry, fullBaseUrl, branches.length > 1),
+    label: branchEntry.versionSelectorLabel,
     isStableBranch: !!branchEntry.isStableBranch,
   }));
 };


### PR DESCRIPTION
### Context
Adds version selector labels to branch entries for consuming applications to action with as they need.

See:
https://jira.mongodb.org/browse/DOP-4006
https://mongodb.slack.com/archives/C018UTGP23T/p1694021032350419