### PR TITLE
DOP 4118: added docset compatibility

### DIFF
--- a/src/services/pool.ts
+++ b/src/services/pool.ts
@@ -83,6 +83,19 @@ export const initPoolDb = (client: MongoClient) => {
 
 export const findAllRepos = async (options: FindOptions = {}, reqId?: string) => {
   try {
+    const defaultSort: FindOptions = {
+      sort: { repoName: 1 },
+    };
+    const strictOptions: FindOptions = {
+      projection: {
+        repoName: 1,
+        project: 1,
+        branches: 1,
+        url: 1,
+        prefix: 1,
+      },
+    };
+    const findOptions = { ...defaultSort, ...options, ...strictOptions };
     const pipeline = [
       { $match: { internalOnly: false } },
       {
@@ -94,7 +107,7 @@ export const findAllRepos = async (options: FindOptions = {}, reqId?: string) =>
         },
       },
     ];
-    const cursor = await db.collection(REPOS_COLLECTION).aggregate(pipeline);
+    const cursor = await db.collection(REPOS_COLLECTION).aggregate(pipeline, findOptions);
     const res = await cursor.toArray();
     return res.map((element) => {
       return mapDocsetRepo(<DocsetRepoDocument>element);

--- a/src/services/pool.ts
+++ b/src/services/pool.ts
@@ -1,4 +1,4 @@
-import { Db, Filter, FindOptions, MongoClient, WithId, ObjectId } from 'mongodb';
+import { Db, FindOptions, MongoClient, WithId, ObjectId } from 'mongodb';
 import { createMessage, initiateLogger } from './logger';
 import { assertTrailingSlash } from '../utils';
 

--- a/src/services/pool.ts
+++ b/src/services/pool.ts
@@ -130,7 +130,7 @@ const mapBranches = (branches: BranchEntry[], fullBaseUrl: string) => {
   }));
 };
 
-const mapDocsetRepo = (docsetRepo: DocsetRepoDocument) => {
+const mapDocsetRepo = (docsetRepo: DocsetRepoDocument): RepoResponse => {
   const docset = docsetRepo.docset ? docsetRepo.docset[0] : null;
   const branches = docset
     ? mapBranches(docsetRepo.branches, getRepoUrl(docset.url[ENV_URL_KEY], docset.prefix[ENV_URL_KEY]))

--- a/tests/globalSetup.ts
+++ b/tests/globalSetup.ts
@@ -4,6 +4,7 @@ import { samplePageDocuments } from './sampleData/documents';
 import { sampleUpdatedPageDocuments } from './sampleData/updatedDocuments';
 import { sampleMetadata } from './sampleData/metadata';
 import { sampleReposBranches } from './sampleData/reposBranches';
+import { sampleDocsets } from './sampleData/docsets';
 import sampleAssets from './sampleData/assets.json';
 
 const loadSampleDataInCollection = async (db: Db, documents: any, collectionName: string) => {
@@ -21,6 +22,7 @@ const loadData = async () => {
   await loadSampleDataInCollection(db, sampleMetadata, 'metadata');
   await loadSampleDataInCollection(db, sampleAssets, 'assets');
   await loadSampleDataInCollection(poolDB, sampleReposBranches, 'repos_branches');
+  await loadSampleDataInCollection(poolDB, sampleDocsets, 'docsets');
 
   await client.close();
 };

--- a/tests/sampleData/docsets.ts
+++ b/tests/sampleData/docsets.ts
@@ -1,0 +1,94 @@
+import { ObjectId } from 'mongodb';
+
+export const sampleDocsets = [
+  {
+    _id: new ObjectId('6500937d24fcc731b4735c9a'),
+    project: 'cloud-docs',
+    bucket: {
+      regression: 'docs-atlas-stg',
+      dev: 'docs-atlas-dev',
+      stg: 'docs-atlas-stg',
+      prd: 'docs-atlas-prd',
+      dotcomstg: 'docs-atlas-dotcomstg',
+      dotcomprd: 'docs-atlas-dotcomprd',
+    },
+    directories: {
+      snooty_toml: '/cloud-docs',
+    },
+    prefix: {
+      stg: '',
+      prd: '',
+      dotcomstg: 'docs-qa/atlas',
+      dotcomprd: 'docs-qa/atlas',
+    },
+    repos: [new ObjectId('5fc999ce3f17b4e8917e0494'), new ObjectId('651ee0dd723f30893f27583f')],
+    url: {
+      regression: 'https://docs-atlas-integration.mongodb.com',
+      dev: 'https://docs-atlas-staging.mongodb.com',
+      stg: 'https://docs-atlas-staging.mongodb.com',
+      prd: 'https://docs.atlas.mongodb.com',
+      dotcomprd: 'https://mongodbcom-cdn.website.staging.corp.mongodb.com/',
+      dotcomstg: 'https://mongodbcom-cdn.website.staging.corp.mongodb.com/',
+    },
+  },
+  {
+    _id: new ObjectId('6500937e24fcc731b4735d8b'),
+    project: 'landing',
+    bucket: {
+      regression: 'docs-mongodb-org-stg',
+      dev: 'docs-mongodb-org-dev',
+      stg: 'docs-mongodb-org-stg',
+      prd: 'docs-mongodb-org-prd',
+      dotcomstg: 'docs-mongodb-org-dotcomstg',
+      dotcomprd: 'docs-mongodb-org-dotcomprd',
+    },
+    directories: {
+      snooty_toml: '/docs-landing',
+    },
+    prefix: {
+      stg: '/',
+      prd: '/',
+      dotcomstg: 'docs-qa',
+      dotcomprd: 'docs-qa',
+    },
+    repos: [new ObjectId('5f6aaeb682989d521a60636a'), new ObjectId('651ee377723f30893f275842')],
+    url: {
+      regression: 'https://docs-mongodbcom-integration.corp.mongodb.com',
+      dev: 'https://docs-mongodborg-staging.corp.mongodb.com',
+      stg: 'https://docs-mongodborg-staging.corp.mongodb.com',
+      prd: 'https://docs.mongodb.com',
+      dotcomprd: 'http://mongodb.com/',
+      dotcomstg: 'https://mongodbcom-cdn.website.staging.corp.mongodb.com/',
+    },
+  },
+  {
+    _id: new ObjectId('6500937d24fcc731b4735cff'),
+    project: 'docs',
+    bucket: {
+      regression: 'docs-mongodb-org-stg',
+      dev: 'docs-mongodb-org-dev',
+      stg: 'docs-mongodb-org-stg',
+      prd: 'docs-mongodb-org-prd',
+      dotcomstg: 'docs-mongodb-org-dotcomstg',
+      dotcomprd: 'docs-mongodb-org-dotcomprd',
+    },
+    directories: {
+      snooty_toml: '/docs',
+    },
+    prefix: {
+      stg: '',
+      prd: '',
+      dotcomstg: 'docs-qa',
+      dotcomprd: 'docs',
+    },
+    repos: [new ObjectId('5fac1ce373a72fca02ec90c5'), new ObjectId('614b9f5b8d181382ca755ade')],
+    url: {
+      regression: 'https://docs-mongodbcom-integration.corp.mongodb.com',
+      dev: 'https://docs-mongodborg-staging.corp.mongodb.com',
+      stg: 'https://docs-mongodborg-staging.corp.mongodb.com',
+      prd: 'https://docs.mongodb.com',
+      dotcomprd: 'http://mongodb.com/',
+      dotcomstg: 'https://mongodbcom-cdn.website.staging.corp.mongodb.com/',
+    },
+  },
+];


### PR DESCRIPTION
[DOP-4118](https://jira.mongodb.org/browse/DOP-4118)

This resolves the error mentioned in the ticket by pulling from `docsets` to fill in the missing data. However, I'm not sure if this fix is the cleanest way to do this since it involves querying from the database two separate times. I'm also not sure if this fix adheres too specifically to the structure of `repos_branches` and `docsets` right now or if it could have a better structure that would work with future changes (e.g. monorepo stuff?).

