### PR TITLE
DOP-3822: Add appName to MongoClient

### DIFF
--- a/src/services/client.ts
+++ b/src/services/client.ts
@@ -1,10 +1,11 @@
 import { MongoClient } from 'mongodb';
 import { createMessage, initiateLogger } from './logger';
 
+const APP_NAME = 'snooty-data-api';
 const ATLAS_URI = process.env.ATLAS_URI ?? '';
 const logger = initiateLogger();
 
-const client = new MongoClient(ATLAS_URI);
+const client = new MongoClient(ATLAS_URI, { appName: APP_NAME });
 
 export const connect = async () => {
   try {


### PR DESCRIPTION
### Ticket

DOP-3822

### How to test

1) Run the server locally
2) Go to any existing endpoint on localhost such as `/projects`
3) Download the database logs from our cluster on Atlas
4) Verify that there is a recent connection with the name "snooty-data-api". For testing purposes, the name can be changed and the steps can be repeated to verify the new name.

### Notes

* There should be no performance or behavioral impact for this change. The main goal of this change is to include a new app name for auditing purposes whenever we look at our Atlas cluster's logs.