### PR TITLE
DOP-4117: Enable horizontal pod autoscaling and probing

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -28,8 +28,6 @@ name: staging-build
 trigger:
   branch:
   - main
-  # TODO-4117: Remove when finished testing
-  - DOP-4117
   event:
   - push
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -28,6 +28,8 @@ name: staging-build
 trigger:
   branch:
   - main
+  # TODO-4117: Remove when finished testing
+  - DOP-4117
   event:
   - push
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ RUN npm ci --omit=dev
 COPY --from=builder /app/dist ./dist
 
 EXPOSE 3000
-CMD ["node", "--max-old-space-size=2048", "dist/index.js"]
+CMD ["node", "--max-old-space-size=3072", "dist/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ RUN npm ci --omit=dev
 COPY --from=builder /app/dist ./dist
 
 EXPOSE 3000
-CMD ["node", "dist/index.js"]
+CMD ["node", "--max-old-space-size=2048", "dist/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ RUN npm ci --omit=dev
 COPY --from=builder /app/dist ./dist
 
 EXPOSE 3000
-CMD ["node", "--max-old-space-size=3072", "dist/index.js"]
+CMD ["node", "--max-old-space-size=2304", "dist/index.js"]

--- a/environments/production.yml
+++ b/environments/production.yml
@@ -16,8 +16,56 @@ ingress:
   hosts:
     - snooty-data-api.docs.prod.corp.mongodb.com
 
+# Current limits and requests are based around metrics during expected peaks
 resources:
   limits:
-    memory: 1300Mi
+    memory: 2Gi
   requests:
     memory: 1100Mi
+
+# The current probes are pretty lenient to avoid prematurely shutting down
+# pods during mass fetches. They should be adjusted accordingly in the future
+probes:
+  enabled: true
+  path: /liveness
+  headers: {}
+  # Determines if the pod is still alive. The pod will shut down if this fails.
+  liveness:
+    httpGet: true
+    initialDelaySeconds: 10
+    periodSeconds: 30
+    # Ideally, timeout would be lower, but this prevents any latency during memory spikes
+    timeoutSeconds: 10
+    successThreshold: 1
+    # Keeping failureThreshold for liveness higher than readiness to ensure
+    # pod stays up even if it's not ready
+    failureThreshold: 6
+  # Determines when the pod is ready to receive traffic. This may help with ensuring that requests
+  # don't disappear into the void when routed to a new pod that isn't ready yet
+  readiness:
+    httpGet: true
+    initialDelaySeconds: 10
+    periodSeconds: 30
+    timeoutSeconds: 10
+    successThreshold: 1
+    failureThreshold: 3
+
+autoscaling:
+  apiVersion: autoscaling/v2
+  minReplicas: 2
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 60
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 0 # scaleUp immediately if conditions met
+      policies:
+        # 100% of the currently running replicas may at most be added every 60s
+        - type: Percent
+          value: 100
+          periodSeconds: 60

--- a/environments/production.yml
+++ b/environments/production.yml
@@ -59,8 +59,11 @@ autoscaling:
   metrics:
     - type: Resource
       resource:
-        # Use cpu instead of memory since it's a more accurate metric for current usage for our API
         name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 75
+        name: memory
         target:
           type: Utilization
           averageUtilization: 75

--- a/environments/production.yml
+++ b/environments/production.yml
@@ -65,7 +65,13 @@ autoscaling:
     scaleUp:
       stabilizationWindowSeconds: 0 # scaleUp immediately if conditions met
       policies:
-        # 100% of the currently running replicas may at most be added every 60s
-        - type: Percent
-          value: 100
+        - type: Pods
+          value: 1
           periodSeconds: 60
+    scaleDown:
+     stabilizationWindowSeconds: 600
+     policies:
+      # Take down 1 pod every 600 seconds, assuming usage is stable
+       - type: Pods
+         value: 1
+         periodSeconds: 600

--- a/environments/production.yml
+++ b/environments/production.yml
@@ -19,9 +19,11 @@ ingress:
 # Current limits and requests are based around metrics during expected peaks
 resources:
   limits:
-    memory: 2Gi
+    memory: 3Gi
+    cpu: 2
   requests:
     memory: 1100Mi
+    cpu: 400m
 
 # The current probes are pretty lenient to avoid prematurely shutting down
 # pods during mass fetches. They should be adjusted accordingly in the future
@@ -57,10 +59,11 @@ autoscaling:
   metrics:
     - type: Resource
       resource:
-        name: memory
+        # Use cpu instead of memory since it's a more accurate metric for current usage for our API
+        name: cpu
         target:
           type: Utilization
-          averageUtilization: 60
+          averageUtilization: 75
   behavior:
     scaleUp:
       stabilizationWindowSeconds: 0 # scaleUp immediately if conditions met
@@ -69,9 +72,9 @@ autoscaling:
           value: 1
           periodSeconds: 60
     scaleDown:
-     stabilizationWindowSeconds: 600
+     stabilizationWindowSeconds: 60
      policies:
-      # Take down 1 pod every 600 seconds, assuming usage is stable
+      # Take down 1 pod every 60 seconds, assuming usage is stable
        - type: Pods
          value: 1
-         periodSeconds: 600
+         periodSeconds: 60

--- a/environments/staging.yml
+++ b/environments/staging.yml
@@ -22,8 +22,10 @@ ingress:
 resources:
   limits:
     memory: 3Gi
+    cpu: 2
   requests:
     memory: 1100Mi
+    cpu: 400m
 
 # The current probes are pretty lenient to avoid prematurely shutting down
 # pods during mass fetches. They should be adjusted accordingly in the future
@@ -59,10 +61,11 @@ autoscaling:
   metrics:
     - type: Resource
       resource:
-        name: memory
+        # Use cpu instead of memory since it's a more accurate metric for current usage for our API
+        name: cpu
         target:
           type: Utilization
-          averageUtilization: 60
+          averageUtilization: 75
   behavior:
     scaleUp:
       stabilizationWindowSeconds: 0 # scaleUp immediately if conditions met
@@ -71,9 +74,9 @@ autoscaling:
           value: 1
           periodSeconds: 60
     scaleDown:
-     stabilizationWindowSeconds: 300
+     stabilizationWindowSeconds: 60
      policies:
-      # Take down 1 pod every 300 seconds, assuming usage is stable
+      # Take down 1 pod every 60 seconds, assuming usage is stable
        - type: Pods
          value: 1
-         periodSeconds: 300
+         periodSeconds: 60

--- a/environments/staging.yml
+++ b/environments/staging.yml
@@ -26,21 +26,20 @@ resources:
 
 autoscaling:
   apiVersion: autoscaling/v2
-  spec:
-    minReplicas: 2
-    maxReplicas: 5
-    metrics:
-      - type: Resource
-        resource:
-          name: memory
-          target:
-            type: Utilization
-            averageUtilization: 60
-    behavior:
-      scaleUp:
-        stabilizationWindowSeconds: 0 # scaleUp immediately if conditions met
-        policies:
-          # 100% of the currently running replicas may at most be added every 60s
-          - type: Percent
-            value: 100
-            periodSeconds: 60
+  minReplicas: 2
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 60
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 0 # scaleUp immediately if conditions met
+      policies:
+        # 100% of the currently running replicas may at most be added every 60s
+        - type: Percent
+          value: 100
+          periodSeconds: 60

--- a/environments/staging.yml
+++ b/environments/staging.yml
@@ -32,14 +32,14 @@ probes:
     httpGet: true
     initialDelaySeconds: 10
     periodSeconds: 60
-    timeoutSeconds: 1
+    timeoutSeconds: 10
     successThreshold: 1
-    failureThreshold: 5
+    failureThreshold: 10
   # Determines when the pod is ready to receive traffic
   readiness:
     initialDelaySeconds: 10
     periodSeconds: 30
-    timeoutSeconds: 1
+    timeoutSeconds: 10
     successThreshold: 1
     failureThreshold: 3
 

--- a/environments/staging.yml
+++ b/environments/staging.yml
@@ -3,13 +3,15 @@ service:
 
 env:
   PORT: 3000
-  SNOOTY_DB_NAME: snooty_stage
-  SNOOTY_PROD_DB_NAME: snooty_dotcomstg
-  POOL_DB_NAME: pool_test
-  SNOOTY_ENV: dotcomstg
+  # TODO-4117: Change back to staging values
+  SNOOTY_DB_NAME: snooty_prod
+  SNOOTY_PROD_DB_NAME: snooty_dotcomprd
+  POOL_DB_NAME: pool
+  SNOOTY_ENV: dotcomprd
 
 envSecrets:
-  ATLAS_URI: snooty-data-api-staging
+  # TODO-4117: Change back to staging
+  ATLAS_URI: snooty-data-api
 
 ingress:
   enabled: true
@@ -21,3 +23,14 @@ resources:
     memory: 1300Mi
   requests:
     memory: 1100Mi
+
+autoscaling:
+  minReplicas: 2
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 50

--- a/environments/staging.yml
+++ b/environments/staging.yml
@@ -3,13 +3,15 @@ service:
 
 env:
   PORT: 3000
-  SNOOTY_DB_NAME: snooty_stage
-  SNOOTY_PROD_DB_NAME: snooty_dotcomstg
-  POOL_DB_NAME: pool_test
-  SNOOTY_ENV: dotcomstg
+  # TODO-4117: Change back to staging values
+  SNOOTY_DB_NAME: snooty_prod
+  SNOOTY_PROD_DB_NAME: snooty_dotcomprd
+  POOL_DB_NAME: pool
+  SNOOTY_ENV: dotcomprd
 
 envSecrets:
-  ATLAS_URI: snooty-data-api-staging
+  # TODO-4117: Change back to staging
+  ATLAS_URI: snooty-data-api
 
 ingress:
   enabled: true

--- a/environments/staging.yml
+++ b/environments/staging.yml
@@ -3,15 +3,13 @@ service:
 
 env:
   PORT: 3000
-  # TODO-4117: Change back to staging values
-  SNOOTY_DB_NAME: snooty_prod
-  SNOOTY_PROD_DB_NAME: snooty_dotcomprd
-  POOL_DB_NAME: pool
-  SNOOTY_ENV: dotcomprd
+  SNOOTY_DB_NAME: snooty_stage
+  SNOOTY_PROD_DB_NAME: snooty_dotcomstg
+  POOL_DB_NAME: pool_test
+  SNOOTY_ENV: dotcomstg
 
 envSecrets:
-  # TODO-4117: Change back to staging
-  ATLAS_URI: snooty-data-api
+  ATLAS_URI: snooty-data-api-staging
 
 ingress:
   enabled: true

--- a/environments/staging.yml
+++ b/environments/staging.yml
@@ -24,25 +24,25 @@ resources:
   requests:
     memory: 1100Mi
 
-probes:
-  enabled: true
-  path: /liveness
-  headers: {}
-  liveness:
-    httpGet: true
-    initialDelaySeconds: 10
-    periodSeconds: 60
-    timeoutSeconds: 1
-    successThreshold: 1
-    failureThreshold: 3
-  # Determines when the pod is ready to receive traffic
-  readiness:
-    initialDelaySeconds: 5
-    # Check every 10 seconds on startup
-    periodSeconds: 10
-    timeoutSeconds: 1
-    successThreshold: 1
-    failureThreshold: 3
+# probes:
+#   enabled: true
+#   path: /liveness
+#   headers: {}
+#   liveness:
+#     httpGet: true
+#     initialDelaySeconds: 10
+#     periodSeconds: 60
+#     timeoutSeconds: 1
+#     successThreshold: 1
+#     failureThreshold: 3
+#   # Determines when the pod is ready to receive traffic
+#   readiness:
+#     initialDelaySeconds: 5
+#     # Check every 10 seconds on startup
+#     periodSeconds: 10
+#     timeoutSeconds: 1
+#     successThreshold: 1
+#     failureThreshold: 3
 
 autoscaling:
   apiVersion: autoscaling/v2

--- a/environments/staging.yml
+++ b/environments/staging.yml
@@ -24,25 +24,25 @@ resources:
   requests:
     memory: 1100Mi
 
-# probes:
-#   enabled: true
-#   path: /liveness
-#   headers: {}
-#   liveness:
-#     httpGet: true
-#     initialDelaySeconds: 10
-#     periodSeconds: 60
-#     timeoutSeconds: 1
-#     successThreshold: 1
-#     failureThreshold: 3
-#   # Determines when the pod is ready to receive traffic
-#   readiness:
-#     initialDelaySeconds: 5
-#     # Check every 10 seconds on startup
-#     periodSeconds: 10
-#     timeoutSeconds: 1
-#     successThreshold: 1
-#     failureThreshold: 3
+probes:
+  enabled: true
+  path: /liveness
+  headers: {}
+  liveness:
+    httpGet: true
+    initialDelaySeconds: 10
+    periodSeconds: 60
+    timeoutSeconds: 1
+    successThreshold: 1
+    failureThreshold: 3
+  # Determines when the pod is ready to receive traffic
+  readiness:
+    initialDelaySeconds: 5
+    # Check every 10 seconds on startup
+    periodSeconds: 10
+    timeoutSeconds: 1
+    successThreshold: 1
+    failureThreshold: 3
 
 autoscaling:
   apiVersion: autoscaling/v2

--- a/environments/staging.yml
+++ b/environments/staging.yml
@@ -3,14 +3,13 @@ service:
 
 env:
   PORT: 3000
-  # TODO-4117: Change config back
-  SNOOTY_DB_NAME: snooty_prod
-  SNOOTY_PROD_DB_NAME: snooty_dotcomprd
-  POOL_DB_NAME: pool
-  SNOOTY_ENV: dotcomprd
+  SNOOTY_DB_NAME: snooty_stage
+  SNOOTY_PROD_DB_NAME: snooty_dotcomstg
+  POOL_DB_NAME: pool_test
+  SNOOTY_ENV: dotcomstg
 
 envSecrets:
-  ATLAS_URI: snooty-data-api
+  ATLAS_URI: snooty-data-api-staging
 
 ingress:
   enabled: true

--- a/environments/staging.yml
+++ b/environments/staging.yml
@@ -18,16 +18,20 @@ ingress:
   hosts:
     - snooty-data-api.docs.staging.corp.mongodb.com
 
+# Current limits and requests are based around metrics during expected peaks
 resources:
   limits:
     memory: 2Gi
   requests:
     memory: 1100Mi
 
+# The current probes are pretty lenient to avoid prematurely shutting down
+# pods during mass fetches. They should be adjusted accordingly in the future
 probes:
   enabled: true
   path: /liveness
   headers: {}
+  # Determines if the pod is still alive. The pod will shut down if this fails.
   liveness:
     httpGet: true
     initialDelaySeconds: 10
@@ -38,7 +42,8 @@ probes:
     # Keeping failureThreshold for liveness higher than readiness to ensure
     # pod stays up even if it's not ready
     failureThreshold: 6
-  # Determines when the pod is ready to receive traffic
+  # Determines when the pod is ready to receive traffic. This may help with ensuring that requests
+  # don't disappear into the void when routed to a new pod that isn't ready yet
   readiness:
     httpGet: true
     initialDelaySeconds: 10
@@ -62,7 +67,13 @@ autoscaling:
     scaleUp:
       stabilizationWindowSeconds: 0 # scaleUp immediately if conditions met
       policies:
-        # 100% of the currently running replicas may at most be added every 60s
-        - type: Percent
-          value: 100
+        - type: Pods
+          value: 1
           periodSeconds: 60
+    scaleDown:
+     stabilizationWindowSeconds: 600
+     policies:
+      # Take down 1 pod every 600 seconds, assuming usage is stable
+       - type: Pods
+         value: 1
+         periodSeconds: 600

--- a/environments/staging.yml
+++ b/environments/staging.yml
@@ -25,12 +25,22 @@ resources:
     memory: 1100Mi
 
 autoscaling:
-  minReplicas: 2
-  maxReplicas: 5
-  metrics:
-    - type: Resource
-      resource:
-        name: memory
-        target:
-          type: Utilization
-          averageUtilization: 50
+  apiVersion: autoscaling/v2
+  spec:
+    minReplicas: 2
+    maxReplicas: 5
+    metrics:
+      - type: Resource
+        resource:
+          name: memory
+          target:
+            type: Utilization
+            averageUtilization: 60
+    behavior:
+      scaleUp:
+        stabilizationWindowSeconds: 0 # scaleUp immediately if conditions met
+        policies:
+          # 100% of the currently running replicas may at most be added every 60s
+          - type: Percent
+            value: 100
+            periodSeconds: 60

--- a/environments/staging.yml
+++ b/environments/staging.yml
@@ -31,10 +31,13 @@ probes:
   liveness:
     httpGet: true
     initialDelaySeconds: 10
-    periodSeconds: 60
+    periodSeconds: 30
+    # Ideally, timeout would be lower, but this prevents any latency during memory spikes
     timeoutSeconds: 10
     successThreshold: 1
-    failureThreshold: 10
+    # Keeping failureThreshold for liveness higher than readiness to ensure
+    # pod stays up even if it's not ready
+    failureThreshold: 6
   # Determines when the pod is ready to receive traffic
   readiness:
     httpGet: true

--- a/environments/staging.yml
+++ b/environments/staging.yml
@@ -37,6 +37,7 @@ probes:
     failureThreshold: 10
   # Determines when the pod is ready to receive traffic
   readiness:
+    httpGet: true
     initialDelaySeconds: 10
     periodSeconds: 30
     timeoutSeconds: 10

--- a/environments/staging.yml
+++ b/environments/staging.yml
@@ -71,9 +71,9 @@ autoscaling:
           value: 1
           periodSeconds: 60
     scaleDown:
-     stabilizationWindowSeconds: 600
+     stabilizationWindowSeconds: 300
      policies:
-      # Take down 1 pod every 600 seconds, assuming usage is stable
+      # Take down 1 pod every 300 seconds, assuming usage is stable
        - type: Pods
          value: 1
-         periodSeconds: 600
+         periodSeconds: 300

--- a/environments/staging.yml
+++ b/environments/staging.yml
@@ -20,7 +20,7 @@ ingress:
 
 resources:
   limits:
-    memory: 1300Mi
+    memory: 2Gi
   requests:
     memory: 1100Mi
 

--- a/environments/staging.yml
+++ b/environments/staging.yml
@@ -24,6 +24,26 @@ resources:
   requests:
     memory: 1100Mi
 
+probes:
+  enabled: true
+  path: /liveness
+  headers: {}
+  liveness:
+    httpGet: true
+    initialDelaySeconds: 10
+    periodSeconds: 60
+    timeoutSeconds: 1
+    successThreshold: 1
+    failureThreshold: 3
+  # Determines when the pod is ready to receive traffic
+  readiness:
+    initialDelaySeconds: 5
+    # Check every 10 seconds on startup
+    periodSeconds: 10
+    timeoutSeconds: 1
+    successThreshold: 1
+    failureThreshold: 3
+
 autoscaling:
   apiVersion: autoscaling/v2
   minReplicas: 2

--- a/environments/staging.yml
+++ b/environments/staging.yml
@@ -3,13 +3,14 @@ service:
 
 env:
   PORT: 3000
-  SNOOTY_DB_NAME: snooty_stage
-  SNOOTY_PROD_DB_NAME: snooty_dotcomstg
-  POOL_DB_NAME: pool_test
-  SNOOTY_ENV: dotcomstg
+  # TODO-4117: Change config back
+  SNOOTY_DB_NAME: snooty_prod
+  SNOOTY_PROD_DB_NAME: snooty_dotcomprd
+  POOL_DB_NAME: pool
+  SNOOTY_ENV: dotcomprd
 
 envSecrets:
-  ATLAS_URI: snooty-data-api-staging
+  ATLAS_URI: snooty-data-api
 
 ingress:
   enabled: true
@@ -59,8 +60,11 @@ autoscaling:
   metrics:
     - type: Resource
       resource:
-        # Use cpu instead of memory since it's a more accurate metric for current usage for our API
         name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 75
+        name: memory
         target:
           type: Utilization
           averageUtilization: 75

--- a/environments/staging.yml
+++ b/environments/staging.yml
@@ -21,7 +21,7 @@ ingress:
 # Current limits and requests are based around metrics during expected peaks
 resources:
   limits:
-    memory: 2Gi
+    memory: 3Gi
   requests:
     memory: 1100Mi
 

--- a/environments/staging.yml
+++ b/environments/staging.yml
@@ -34,12 +34,11 @@ probes:
     periodSeconds: 60
     timeoutSeconds: 1
     successThreshold: 1
-    failureThreshold: 3
+    failureThreshold: 5
   # Determines when the pod is ready to receive traffic
   readiness:
-    initialDelaySeconds: 5
-    # Check every 10 seconds on startup
-    periodSeconds: 10
+    initialDelaySeconds: 10
+    periodSeconds: 30
     timeoutSeconds: 1
     successThreshold: 1
     failureThreshold: 3

--- a/src/app.ts
+++ b/src/app.ts
@@ -54,11 +54,8 @@ export const setupApp = async ({ mongoClient }: AppSettings) => {
   }
 
   const app = express();
-  // Keep away from other endpoints since reqHandler would just spam logs for liveness
-  app.use('/liveness', livenessRouter);
-
-  // The following routes will be preceded by the reqHandler
   app.use(reqHandler);
+  app.use('/liveness', livenessRouter);
   app.use('/builds', buildsRouter);
   app.use('/projects', projectsRouter);
   app.use('/user', userRouter);

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,7 @@ import dotenv from 'dotenv';
 import { MongoClient, ObjectId } from 'mongodb';
 // Configure dotenv early so env variables can be read in imported files
 dotenv.config();
+import livenessRouter from './routes/liveness';
 import buildsRouter from './routes/builds';
 import projectsRouter from './routes/projects';
 import userRouter from './routes/user';
@@ -53,6 +54,10 @@ export const setupApp = async ({ mongoClient }: AppSettings) => {
   }
 
   const app = express();
+  // Keep away from other endpoints since reqHandler would just spam logs for liveness
+  app.use('/liveness', livenessRouter);
+
+  // The following routes will be preceded by the reqHandler
   app.use(reqHandler);
   app.use('/builds', buildsRouter);
   app.use('/projects', projectsRouter);

--- a/src/app.ts
+++ b/src/app.ts
@@ -55,12 +55,12 @@ export const setupApp = async ({ mongoClient }: AppSettings) => {
 
   const app = express();
   app.use(reqHandler);
-  app.use('/liveness', livenessRouter);
   app.use('/builds', buildsRouter);
   app.use('/projects', projectsRouter);
   app.use('/user', userRouter);
   app.use('/prod/builds', buildsRouter);
   app.use('/prod/projects', projectsRouter);
+  app.use('/liveness', livenessRouter);
   app.use(errorHandler);
   app.disable('x-powered-by');
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -54,13 +54,16 @@ export const setupApp = async ({ mongoClient }: AppSettings) => {
   }
 
   const app = express();
+
+  // Keep this above the reqHandler since logs for this probe might result in spam
+  app.use('/liveness', livenessRouter);
+
   app.use(reqHandler);
   app.use('/builds', buildsRouter);
   app.use('/projects', projectsRouter);
   app.use('/user', userRouter);
   app.use('/prod/builds', buildsRouter);
   app.use('/prod/projects', projectsRouter);
-  app.use('/liveness', livenessRouter);
   app.use(errorHandler);
   app.disable('x-powered-by');
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ const startServer = async () => {
   });
 
   server.on('close', () => {
-    logger.info('Server closed.');
+    logger.info('Server closed');
   });
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ const signalHandler = async (signal: string) => {
   server.close();
 };
 
-const signals = ['SIGINT', 'SIGTERM', 'SIGQUIT', 'SIGKILL'];
+const signals = ['SIGINT', 'SIGTERM', 'SIGQUIT'];
 signals.forEach((signal) => {
   process.on(signal, signalHandler);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,10 @@ const startServer = async () => {
   server.on('error', (err) => {
     logger.error(`Server encountered the following error: ${err}`);
   });
+
+  server.on('close', () => {
+    logger.info('Server closed.');
+  });
 };
 
 startServer().catch((e) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,10 @@ const startServer = async () => {
   server = app.listen(PORT, () => {
     logger.info(`Server listening on port: ${PORT}`);
   });
+
+  server.on('error', (err) => {
+    logger.error(`Server encountered the following error: ${err}`);
+  });
 };
 
 startServer().catch((e) => {
@@ -28,6 +32,7 @@ const signalHandler = async (signal: string) => {
   server.close();
 };
 
-process.on('SIGINT', signalHandler);
-process.on('SIGTERM', signalHandler);
-process.on('SIGQUIT', signalHandler);
+const signals = ['SIGINT', 'SIGTERM', 'SIGQUIT', 'SIGKILL'];
+signals.forEach((signal) => {
+  process.on(signal, signalHandler);
+});

--- a/src/routes/liveness.ts
+++ b/src/routes/liveness.ts
@@ -3,7 +3,8 @@ import express from 'express';
 const router = express.Router();
 
 // Simple route that k8s will request in a cadence to ensure the app is live/ready
-router.get('/', async (_req, res, _next) => {
+// eslint-disable-next-line  @typescript-eslint/no-unused-vars
+router.get('/', async (_req, res) => {
   res.sendStatus(200);
 });
 

--- a/src/routes/liveness.ts
+++ b/src/routes/liveness.ts
@@ -1,0 +1,10 @@
+import express from 'express';
+
+const router = express.Router();
+
+// Simple route that k8s will request in a cadence to ensure the app is live/ready
+router.get('/', async (_req, res, _next) => {
+  res.sendStatus(200);
+});
+
+export default router;

--- a/src/services/client.ts
+++ b/src/services/client.ts
@@ -7,6 +7,10 @@ const logger = initiateLogger();
 
 const client = new MongoClient(ATLAS_URI, { appName: APP_NAME });
 
+client.on('topologyClosed', () => {
+  logger.info('Client topology closed');
+});
+
 export const connect = async () => {
   try {
     await client.connect();


### PR DESCRIPTION
### Ticket

DOP-4117

### Notes

* [Example Grafana chart](https://grafana.staging.corp.mongodb.com/d/a164a7f0339f99e89cea5ab47f9be872/memory-profiler-workloads?var-datasource=Prometheus&var-cluster=&var-namespace=docs&var-workload=snooty-data-api-web-app&var-type=Deployment&from=1700591867222&to=1700593959807&orgId=1) of new pods starting up and closing
* Liveness and readiness probes were added to help ensure that any incoming requests are routed to pods that are actually ready to handle requests.
* This initial configuration was tested by streaming fetch requests for all users en masse with production data.
* Most of this configuration is a bit lenient and perhaps imperfect. The goals of this PR should be to help increase visibility within the application (server and MongoDB client closing, etc.) and introduce a basic config for HPA that can be scaled accordingly based on our actual needs in production (simulated behavior on staging vs. actual behavior on prod).