### PR TITLE
DOP-4222: Increase minimum pods to 3

### DIFF
--- a/environments/production.yml
+++ b/environments/production.yml
@@ -54,7 +54,7 @@ probes:
 
 autoscaling:
   apiVersion: autoscaling/v2
-  minReplicas: 2
+  minReplicas: 3
   maxReplicas: 5
   metrics:
     - type: Resource

--- a/environments/staging.yml
+++ b/environments/staging.yml
@@ -54,7 +54,7 @@ probes:
 
 autoscaling:
   apiVersion: autoscaling/v2
-  minReplicas: 2
+  minReplicas: 3
   maxReplicas: 5
   metrics:
     - type: Resource


### PR DESCRIPTION
### Ticket

DOP-4222

### Notes

* This should be a minimal change to increase the minimum number of pods from 2 to 3 in hopes that this will help increase the overall speed in which the API can return data when many large requests are being handled at the same time.
* I ran a script that fetched every user's data. For 2-pod minimum, it took ~27 minutes while a 3-pod minimum took ~13 minutes. Times may vary depending on distribution of requests, internet connection, machine, etc., but I figured this was a good metric to include for context