### PR TITLE
DOP-5251: update projects route to include offline download url

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,8 +4,6 @@ DOP-NNNN
 
 ### Notes
 
-
-
 ### README updates
 
 - - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   lint-and-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3

--- a/src/services/pool.ts
+++ b/src/services/pool.ts
@@ -18,6 +18,7 @@ interface BranchEntry {
   urlAliases: string[];
   isStableBranch: boolean;
   versionSelectorLabel: string;
+  offlineUrl?: string;
   [key: string]: any;
 }
 
@@ -107,6 +108,8 @@ export const findAllRepos = async (options: FindOptions = {}, reqId?: string) =>
         },
       },
     ];
+    console.log('check findOptions ');
+    console.log(findOptions);
     const cursor = await db.collection(REPOS_COLLECTION).aggregate(pipeline, findOptions);
     const res = await cursor.toArray();
     return res.map((element) => {
@@ -140,6 +143,7 @@ const mapBranches = (branches: BranchEntry[], fullBaseUrl: string) => {
     fullUrl: getBranchFullUrl(branchEntry, fullBaseUrl, branches.length > 1),
     label: branchEntry.versionSelectorLabel,
     isStableBranch: !!branchEntry.isStableBranch,
+    offlineUrl: branchEntry.offlineUrl,
   }));
 };
 

--- a/src/services/pool.ts
+++ b/src/services/pool.ts
@@ -18,6 +18,7 @@ interface BranchEntry {
   urlAliases: string[];
   isStableBranch: boolean;
   versionSelectorLabel: string;
+  urlSlug: string;
   offlineUrl?: string;
   [key: string]: any;
 }

--- a/src/services/pool.ts
+++ b/src/services/pool.ts
@@ -108,8 +108,6 @@ export const findAllRepos = async (options: FindOptions = {}, reqId?: string) =>
         },
       },
     ];
-    console.log('check findOptions ');
-    console.log(findOptions);
     const cursor = await db.collection(REPOS_COLLECTION).aggregate(pipeline, findOptions);
     const res = await cursor.toArray();
     return res.map((element) => {


### PR DESCRIPTION
### Ticket

DOP-5251

### Notes
- This route already exists on prod to get all the projects and corresponding branches https://snooty-data-api.mongodb.com/projects - Adding onto this route so this also returns the offline download URL for this each page. Currently in `pool.repos_branches` there is a test property under 'cloud-docs - master' branch for `offlineUrl` (generated by [Netlify extension](https://github.com/mongodb/netlify-extensions/pull/55)).
- The proposal is that the front end will use this route to populate the modal for users to see available downloads
- Since staging is Okta auth'ed, testing in staging / docs-qa will require an additional step, as you need to be okta-verified to make requests to the server


### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
