### PR TITLE
DOP-5257: return repos_branches[].displayName 

### DIFF
--- a/src/services/pool.ts
+++ b/src/services/pool.ts
@@ -30,6 +30,7 @@ interface RepoDocument extends WithId<Document> {
   url: EnvKeyedObject;
   prefix: EnvKeyedObject;
   search: Record<string, string>;
+  displayName?: string;
 }
 
 interface EnvKeyedURL {
@@ -59,6 +60,7 @@ export interface BranchResponse {
 }
 
 export interface RepoResponse {
+  displayName?: string;
   repoName: string;
   project: string;
   search: Record<string, string>;
@@ -95,6 +97,7 @@ export const findAllRepos = async (options: FindOptions = {}, reqId?: string) =>
         branches: 1,
         url: 1,
         prefix: 1,
+        displayName: 1,
       },
     };
     const findOptions = { ...defaultSort, ...options, ...strictOptions };
@@ -152,6 +155,7 @@ const mapDocsetRepo = (docsetRepo: DocsetRepoDocument): RepoResponse => {
     ? mapBranches(docsetRepo.branches, getRepoUrl(docset.url[ENV_URL_KEY], docset.prefix[ENV_URL_KEY]))
     : [];
   return {
+    displayName: docsetRepo.displayName,
     repoName: docsetRepo.repoName,
     project: docsetRepo.project,
     search: docsetRepo.search,

--- a/tests/sampleData/reposBranches.ts
+++ b/tests/sampleData/reposBranches.ts
@@ -4,6 +4,7 @@ export const sampleReposBranches = [
   {
     _id: new ObjectId('5fc999ce3f17b4e8917e0494'),
     repoName: 'cloud-docs',
+    displayName: 'MongoDB Atlas',
     branches: [
       {
         name: 'master',
@@ -51,6 +52,7 @@ export const sampleReposBranches = [
   {
     _id: new ObjectId('5f6aaeb682989d521a60636a'),
     repoName: 'docs-landing',
+    displayName: 'MongoDB Documentation',
     branches: [
       {
         name: 'master',
@@ -94,6 +96,7 @@ export const sampleReposBranches = [
   {
     _id: new ObjectId('5fac1ce373a72fca02ec90c5'),
     repoName: 'docs',
+    displayName: 'MongoDB Manual',
     branches: [
       {
         id: new ObjectId('6447e9e7e033e0a801c80f56'),
@@ -349,6 +352,7 @@ export const sampleReposBranches = [
   {
     _id: new ObjectId('614b9f5b8d181382ca755ade'),
     repoName: 'docs-mongodb-internal',
+    displayName: 'MongoDB Manual',
     branches: [
       {
         id: new ObjectId('62e293ce8b1d857926ab4cca'),


### PR DESCRIPTION
### Ticket

DOP-5257

See related snooty frontend pull request [here](https://github.com/mongodb/snooty/pull/1336/files#diff-761298fef9a5f3d4437e7041e5779a3acc7e775523be56494785ce2ceeb9afacR30-R38). Realized we have this field in the DB but not returned in our current API routes [example route](https://snooty-data-api.mongodb.com/projects)


### Notes

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
