### PR TITLE
DOP-5192: add facets field to updated pages

### DIFF
--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -7,6 +7,13 @@ interface StaticAsset {
   updated_at?: Date;
 }
 
+interface Facet {
+  categroy: string;
+  value: string;
+  display_name: string;
+  sub_facets?: { [key: string]: any }[];
+}
+
 export interface AssetDocument {
   _id: string;
   data: BinaryData;
@@ -22,6 +29,7 @@ interface PageDocument {
   build_id: ObjectId;
   created_at: Date;
   github_username: string;
+  facets?: Facet[];
 }
 
 interface UpdatedPageDocument {
@@ -34,6 +42,7 @@ interface UpdatedPageDocument {
   updated_at: Date;
   github_username: string;
   deleted: boolean;
+  facets?: Facet[];
 }
 
 export type PageDocType = PageDocument | UpdatedPageDocument;

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -8,7 +8,7 @@ interface StaticAsset {
 }
 
 interface Facet {
-  categroy: string;
+  category: string;
   value: string;
   display_name: string;
   sub_facets?: { [key: string]: any }[];


### PR DESCRIPTION
### Ticket

DOP-5192

### Notes
- This change does not functionally change anything. "facet" field is already returned within a a document, if they are read from the `documents` collection. (example [here](https://snooty-data-api.docs.staging.corp.mongodb.com/prod/builds/67856cf17786f249ee1726a6/documents))
- The `updated_documents` collection should return the "facets" field after [this related change](https://github.com/mongodb/docs-worker-pool/pull/1080). [This route](https://snooty-data-api.docs.staging.corp.mongodb.com/prod/projects/cloud-docs/documents) reads from updated_collections and has no "facets" field in the documents.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
