### PR TITLE
DOP-5513: allow requests from docs sites

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -6,7 +6,6 @@ name: test
 trigger:
   branch:
   - main
-  - DOP-5513
   event:
   - push
   - tag
@@ -29,7 +28,6 @@ name: staging-build
 trigger:
   branch:
   - main
-  - DOP-5513
   event:
   - push
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -6,6 +6,7 @@ name: test
 trigger:
   branch:
   - main
+  - DOP-5513
   event:
   - push
   - tag
@@ -28,6 +29,7 @@ name: staging-build
 trigger:
   branch:
   - main
+  - DOP-5513
   event:
   - push
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,7 +25,7 @@ export const assertTrailingSlash = (str: string) => {
   return `${str}/`;
 };
 
-const STAGING_HOSTNAME = 'docs-mongodb-org-stg.s3.us-east-2.amazonaws.com';
+const STAGING_HOSTNAME = 'netlify.app';
 const PROD_HOSTNAME = 'mongodb.com';
 
 export const isPermittedOrigin = (origin: string | undefined) => {
@@ -38,6 +38,7 @@ export const isPermittedOrigin = (origin: string | undefined) => {
   }
   return (
     url.protocol == 'https:' &&
-    (url.hostname === STAGING_HOSTNAME || url.hostname.split('.').slice(-2).join('.') === PROD_HOSTNAME)
+    (url.hostname.split('.').slice(-2).join('.') === STAGING_HOSTNAME ||
+      url.hostname.split('.').slice(-2).join('.') === PROD_HOSTNAME)
   );
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,3 +24,20 @@ export const assertTrailingSlash = (str: string) => {
   }
   return `${str}/`;
 };
+
+const STAGING_HOSTNAME = 'docs-mongodb-org-stg.s3.us-east-2.amazonaws.com';
+const PROD_HOSTNAME = 'mongodb.com';
+
+export const isPermittedOrigin = (origin: string | undefined) => {
+  if (!origin) return;
+  let url;
+  try {
+    url = new URL(origin);
+  } catch (err) {
+    return;
+  }
+  return (
+    url.protocol == 'https:' &&
+    (url.hostname === STAGING_HOSTNAME || url.hostname.split('.').slice(-2).join('.') === PROD_HOSTNAME)
+  );
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,15 +29,15 @@ const STAGING_HOSTNAME = 'netlify.app';
 const PROD_HOSTNAME = 'mongodb.com';
 
 export const isPermittedOrigin = (origin: string | undefined) => {
-  if (!origin) return;
+  if (!origin) return false;
   let url;
   try {
     url = new URL(origin);
   } catch (err) {
-    return;
+    return false;
   }
   return (
-    url.protocol == 'https:' &&
+    url.protocol === 'https:' &&
     (url.hostname.split('.').slice(-2).join('.') === STAGING_HOSTNAME ||
       url.hostname.split('.').slice(-2).join('.') === PROD_HOSTNAME)
   );


### PR DESCRIPTION
### Ticket

DOP-5513

### Notes
This PR adds middleware logic to the Express server so that we check the request origin, and append a Response Header for `access-control-allow-origin` to let the browser know that this is an ok CORS request.

### Staging
Tested using the stage API with credentials included in the request:

First screenshot shows `response.header` missing `Access-Control-Allow-Origin` because it is from a random domain:

![Screenshot 2025-03-20 at 9 51 37 AM](https://github.com/user-attachments/assets/309fde49-c62b-4205-8652-f57bb6d52280)

Second screenshot shows `response.header` with `Access-Control-Allow-Origin` because it is from a spoofed `netlify.app` domain:
![Screenshot 2025-03-20 at 9 51 25 AM](https://github.com/user-attachments/assets/4d0f05d2-c187-4565-af3c-7cd0ccaf5ab0)

### Note:
- Above request had to contain `Cookie` request header to bypass CorSecure



### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
